### PR TITLE
Fix JSONDecodeError: Extra Data

### DIFF
--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -193,7 +193,7 @@ class googleimagesdownload:
 
     def _extract_data_pack_ajax(self, data):
         lines = data.split('\n')
-        return json.loads(lines[3] + lines[4])[0][2]
+        return json.loads(lines[3])[0][2]
 
     def _image_objects_from_pack(self, data):
         image_objects = json.loads(data)[31][0][12][2]


### PR DESCRIPTION
This problem, detailed in issue #353, may have been caused by Google changing their Ajax response. Looking at the response, lines[4] only contained a single number and not any JSON. Removing it and simply pulling from lines[3] seems to fix the issue. The problem only manifested when downloading more than 100 images, which required launching ChromeDriver.