### PR TITLE
Manage API change

### DIFF
--- a/google_images_download/google_images_download.py
+++ b/google_images_download/google_images_download.py
@@ -196,7 +196,7 @@ class googleimagesdownload:
         return json.loads(lines[3] + lines[4])[0][2]
 
     def _image_objects_from_pack(self, data):
-        image_objects = json.loads(data)[31][0][12][2]
+        image_objects = json.loads(data)[31][-1][12][2]
         image_objects = [x for x in image_objects if x[0] == 1]
         return image_objects
 


### PR DESCRIPTION
We extracted images from json.loads(data)[31][0]... because in json.loads(data)[31] was a list of 1 value.
Now json.loads(data)[31] is a list of 2 values and we want the last.
So replacing 0 by -1 manage this new case and the old one if Google revert this change.